### PR TITLE
<feat>:新增历史上的今天功能

### DIFF
--- a/bot/biz/command/histoday.go
+++ b/bot/biz/command/histoday.go
@@ -1,0 +1,8 @@
+package command
+
+import "LanMei/bot/utils/histoday"
+
+func Histoday() string {
+	text := histoday.GetHistory()
+	return text
+}

--- a/bot/biz/logic/processor.go
+++ b/bot/biz/logic/processor.go
@@ -33,6 +33,7 @@ const (
 	TAROT       = "/抽塔罗牌"
 	DAILY_LUCK  = "/今日运势"
 	WCLOUD      = "/wcloud"
+	HISTODAY    = "/历史上的今天"
 )
 
 func InitProcessor(api openapi.OpenAPI) {
@@ -128,6 +129,8 @@ func (p *ProcessorImpl) MessageProcess(input string, data dto.Message) *dto.Mess
 			FileInfo = command.WCloud(data.GroupID)
 			MsgType = dto.RichMediaMsg
 			msg = ""
+		case input == HISTODAY:
+			msg = command.Histoday()
 		case len(input) > 1000:
 			msg = "哇~ 你是不是太着急啦？慢慢说，蓝妹在这里听着呢~(●'◡'●)"
 		default:

--- a/bot/utils/histoday/histoday.go
+++ b/bot/utils/histoday/histoday.go
@@ -1,0 +1,44 @@
+package histoday
+
+import (
+	"LanMei/bot/utils/llog"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+const BaseURL = "https://hao.360.cn/histoday"
+
+var hisMatch = regexp.MustCompile(`</em>\.(.*?)</dt>`)
+
+func GetHistory() (text string) {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", BaseURL, nil)
+	if err != nil {
+		llog.Error("创建查询历史请求失败: %v", err)
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		llog.Error("发送查询历史请求失败: %v", err)
+		return
+	}
+	resp, err := io.ReadAll(res.Body)
+	if err != nil {
+		llog.Error("读取查询历史响应失败: %v", err)
+		return
+	}
+	defer res.Body.Close()
+
+	fmt.Println(string(resp))
+
+	his := hisMatch.FindAllStringSubmatch(string(resp), -1)
+	lines := make([]string, len(his))
+	for i := range his {
+		lines[i] = fmt.Sprintf("%d. %s", i+1, his[i][1])
+	}
+	text = fmt.Sprintf("历史上的今天\n%s", strings.Join(lines, "\n"))
+
+	return text
+}


### PR DESCRIPTION
本地单测通了

    histoday_test.go:22: 获取的历史事件: 历史上的今天
        1.  1944年-著名新闻记者邹韬奋在上海逝世
        2.  1977年-作家何其芳逝世
        3.  1802年-法国作家大仲马诞辰
        4.  1783年-拉丁美洲民族英雄玻利瓦尔诞辰
        5.  1828年-俄国作家车尔尼雪夫斯基诞辰
        6.  1985年-第一位漂流长江的人尧茂书身亡
        7.  1190年-“治天下匠”耶律楚材诞辰
        8.  1886年-中英签订《缅甸条款》
        9.  1953年-法国伞兵包围谅山
        10.  1959年-赫鲁晓夫和尼克松展开厨房辩论
        11.  1982年-廖承志致信蒋经国促统一
        12.  1994年-加勒比国家联盟成立
        13.  1998年-美国国会大厦发生枪击事件